### PR TITLE
Allow user to get the direction property

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -132,6 +132,8 @@ typedef enum {
 - (void)dismissAnimated:(BOOL)animated;
 - (id)initWithMessage:(NSString *)messageToShow;
 
+- (PointDirection) getPointDirection;
+
 @end
 
 

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -429,6 +429,10 @@
     return self;
 }
 
+- (PointDirection) getPointDirection {
+  return pointDirection;
+}
+
 - (id)initWithMessage:(NSString *)messageToShow {
 	CGRect frame = CGRectZero;
 	


### PR DESCRIPTION
I was applying tooltips to tableview cells and needed to determine if it was `PointDirectionUp` or `PointDirectionDown` so that I could determine when to dismiss the tooltip when the user scrolled the table view.

A useful addition IMHO.
