### PR TITLE
Added a dismissTapAnywhere option

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -122,11 +122,13 @@ typedef enum {
 	PointDirection			pointDirection;
 	CGFloat					pointerSize;
 	CGPoint					targetPoint;
+    UIButton                *dismissTarget;
 }
 
 @property (nonatomic, retain)			UIColor					*backgroundColor;
 @property (nonatomic, assign)		id<CMPopTipViewDelegate>	delegate;
 @property (nonatomic, assign)			BOOL					disableTapToDismiss;
+@property (nonatomic, assign)			BOOL					dismissTapAnywhere;
 @property (nonatomic, retain)			NSString				*message;
 @property (nonatomic, retain)           UIView	                *customView;
 @property (nonatomic, retain, readonly)	id						targetObject;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -45,6 +45,7 @@
 @synthesize animation;
 @synthesize maxWidth;
 @synthesize disableTapToDismiss;
+@synthesize dismissTapAnywhere;
 
 - (CGRect)bubbleFrame {
 	CGRect bubbleFrame;
@@ -235,6 +236,16 @@
 	if (!self.targetObject) {
 		self.targetObject = targetView;
 	}
+    
+    // If we want to dismiss the bubble when the user taps anywhere, we need to insert
+    // an invisible button over the background.
+    if ( self.dismissTapAnywhere ) {
+        self->dismissTarget = [UIButton buttonWithType:UIButtonTypeCustom];
+        [self->dismissTarget addTarget:self action:@selector(touchesBegan:withEvent:) forControlEvents:UIControlEventTouchUpInside];
+        [self->dismissTarget setTitle:@"" forState:UIControlStateNormal];
+        self->dismissTarget.frame = containerView.bounds;
+        [containerView addSubview:self->dismissTarget];
+    }
 	
 	[containerView addSubview:self];
     
@@ -409,6 +420,11 @@
 
 - (void)finaliseDismiss {
 	[self removeFromSuperview];
+    
+    if ( self->dismissTarget ) {
+        [self->dismissTarget removeFromSuperview];        
+    }
+            
 	highlight = NO;
 	self.targetObject = nil;
 }
@@ -491,6 +507,7 @@
 		self.backgroundColor = [UIColor colorWithRed:62.0/255.0 green:60.0/255.0 blue:154.0/255.0 alpha:1.0];
         self.borderColor = [UIColor blackColor];
         self.animation = CMPopTipAnimationSlide;
+        self.dismissTapAnywhere = NO;
     }
     return self;
 }


### PR DESCRIPTION
Hey,

I am finding the CMPopTipView very useful.

For the app I am working on I didn't want the user to have to tap on the bubble to dismiss it. Tapping anywhere on the screen was fine. So I added an option, _dismissTapAnywhere_, which creates an invisible button on the container view. Tapping this button dismisses the bubble. The option defaults to False - the behaviour is unchanged.

Feel free to pull in the change if you find it useful. (Also feel free to discard if you don't like it!)

Thanks
