### PR TITLE
Added optional title for pop tip view

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -105,8 +105,11 @@ typedef enum {
 @interface CMPopTipView : UIView {
 	UIColor					*backgroundColor;
 	id<CMPopTipViewDelegate>	delegate;
+    NSString                *title;
 	NSString				*message;
 	id						targetObject;
+    UIColor                 *titleColor;
+    UIFont                  *titleFont;
 	UIColor					*textColor;
 	UIFont					*textFont;
     UIColor                 *borderColor;
@@ -128,11 +131,15 @@ typedef enum {
 @property (nonatomic, assign)		id<CMPopTipViewDelegate>	delegate;
 @property (nonatomic, assign)			BOOL					disableTapToDismiss;
 @property (nonatomic, assign)			BOOL					dismissTapAnywhere;
+@property (nonatomic, retain)			NSString				*title;
 @property (nonatomic, retain)			NSString				*message;
 @property (nonatomic, retain)           UIView	                *customView;
 @property (nonatomic, retain, readonly)	id						targetObject;
+@property (nonatomic, retain)			UIColor					*titleColor;
+@property (nonatomic, retain)			UIFont					*titleFont;
 @property (nonatomic, retain)			UIColor					*textColor;
 @property (nonatomic, retain)			UIFont					*textFont;
+@property (nonatomic, assign)			UITextAlignment			titleAlignment;
 @property (nonatomic, assign)			UITextAlignment			textAlignment;
 @property (nonatomic, retain)			UIColor					*borderColor;
 @property (nonatomic, assign)			CGFloat					borderWidth;
@@ -140,6 +147,7 @@ typedef enum {
 @property (nonatomic, assign)           CGFloat                 maxWidth;
 
 /* Contents can be either a message or a UIView */
+- (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow;
 - (id)initWithMessage:(NSString *)messageToShow;
 - (id)initWithCustomView:(UIView *)aView;
 

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -37,11 +37,15 @@
 @synthesize autoDismissTimer = _autoDismissTimer;
 @synthesize backgroundColor;
 @synthesize delegate;
+@synthesize title;
 @synthesize message;
 @synthesize customView;
 @synthesize targetObject;
+@synthesize titleColor;
+@synthesize titleFont;
 @synthesize textColor;
 @synthesize textFont;
+@synthesize titleAlignment;
 @synthesize textAlignment;
 @synthesize borderColor;
 @synthesize borderWidth;
@@ -224,11 +228,28 @@
 	
 	CGPathRelease(bubblePath);
 	
-	// Draw text
+	// Draw title and text
+    
+    if (self.title) {
+        [self.titleColor set];
+        CGRect titleFrame = [self contentFrame];
+        [self.title drawInRect:titleFrame
+                      withFont:self.titleFont
+                 lineBreakMode:UILineBreakModeClip
+                     alignment:self.titleAlignment];
+    }
 	
 	if (self.message) {
 		[textColor set];
 		CGRect textFrame = [self contentFrame];
+        
+        // Move down to make room for title
+        if (self.title) {
+            textFrame.origin.y += [self.title sizeWithFont:self.titleFont
+                                         constrainedToSize:CGSizeMake(textFrame.size.width, 99999.0)
+                                             lineBreakMode:UILineBreakModeClip].height;
+        }
+        
         [self.message drawInRect:textFrame
                         withFont:textFont
                    lineBreakMode:UILineBreakModeWordWrap
@@ -294,6 +315,11 @@
     }
     if (self.customView != nil) {
         textSize = self.customView.frame.size;
+    }
+    if (self.title != nil) {
+        textSize.height += [self.title sizeWithFont:self.titleFont
+                                  constrainedToSize:CGSizeMake(rectWidth, 99999.0)
+                                      lineBreakMode:UILineBreakModeClip].height;
     }
     
 	bubbleSize = CGSizeMake(textSize.width + cornerRadius*2, textSize.height + cornerRadius*2);
@@ -532,6 +558,23 @@
   return pointDirection;
 }
 
+- (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow {
+	CGRect frame = CGRectZero;
+	
+	if ((self = [self initWithFrame:frame])) {
+        self.title = titleToShow;
+		self.message = messageToShow;
+        
+        self.titleFont = [UIFont boldSystemFontOfSize:16.0];
+        self.titleColor = [UIColor whiteColor];
+        self.titleAlignment = UITextAlignmentCenter;
+        self.textFont = [UIFont systemFontOfSize:14.0];
+		self.textColor = [UIColor whiteColor];
+
+	}
+	return self;
+}
+
 - (id)initWithMessage:(NSString *)messageToShow {
 	CGRect frame = CGRectZero;
 	
@@ -557,8 +600,11 @@
 	[backgroundColor release];
     [borderColor release];
     [customView release];
+    [title release];
 	[message release];
 	[targetObject release];
+    [titleColor release];
+    [titleFont release];
 	[textColor release];
 	[textFont release];
 	


### PR DESCRIPTION
Lets you init the pop tip view with title and message, displaying a
separately style-able (font, color, alignment) title string.
