### PR TITLE
Fix shadow cropping + add ability to disable shadow

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -115,6 +115,7 @@ typedef enum {
 	UIFont					*textFont;
     UIColor                 *borderColor;
     CGFloat                 borderWidth;
+    BOOL                    hasShadow;
     CMPopTipAnimation       animation;
 
 	@private
@@ -144,6 +145,7 @@ typedef enum {
 @property (nonatomic, assign)			UITextAlignment			textAlignment;
 @property (nonatomic, retain)			UIColor					*borderColor;
 @property (nonatomic, assign)			CGFloat					borderWidth;
+@property (nonatomic, assign)           BOOL                    hasShadow;
 @property (nonatomic, assign)           CMPopTipAnimation       animation;
 @property (nonatomic, assign)           CGFloat                 maxWidth;
 @property (nonatomic, assign)           PointDirection          preferredPointDirection;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -24,6 +24,7 @@
 //
 
 #import "CMPopTipView.h"
+#import <QuartzCore/QuartzCore.h>
 
 @interface CMPopTipView ()
 @property (nonatomic, retain, readwrite)	id	targetObject;
@@ -49,6 +50,7 @@
 @synthesize textAlignment;
 @synthesize borderColor;
 @synthesize borderWidth;
+@synthesize hasShadow;
 @synthesize animation;
 @synthesize maxWidth;
 @synthesize disableTapToDismiss;
@@ -141,15 +143,6 @@
 	}
     
 	CGPathCloseSubpath(bubblePath);
-    
-	
-	// Draw shadow
-	CGContextAddPath(c, bubblePath);
-    CGContextSaveGState(c);
-	CGContextSetShadow(c, CGSizeMake(0, 3), 5);
-	CGContextSetRGBFillColor(c, 0.0, 0.0, 0.0, 0.9);
-	CGContextFillPath(c);
-    CGContextRestoreGState(c);
     
 	
 	// Draw clipped background gradient
@@ -573,11 +566,23 @@
 		self.textAlignment = UITextAlignmentCenter;
 		self.backgroundColor = [UIColor colorWithRed:62.0/255.0 green:60.0/255.0 blue:154.0/255.0 alpha:1.0];
         self.borderColor = [UIColor blackColor];
+        self.hasShadow = YES;
         self.animation = CMPopTipAnimationSlide;
         self.dismissTapAnywhere = NO;
         self.preferredPointDirection = PointDirectionAny;
     }
     return self;
+}
+
+- (void)setHasShadow:(BOOL)newHasShadow {
+    if (newHasShadow) {
+        self.layer.shadowOffset = CGSizeMake(0, 3);
+        self.layer.shadowRadius = 2.0;
+        self.layer.shadowColor = [[UIColor blackColor] CGColor];
+        self.layer.shadowOpacity = 0.3;
+    } else {
+        self.layer.shadowOpacity = 0.0;
+    }
 }
 
 - (PointDirection) getPointDirection {


### PR DESCRIPTION
Fixed shadow cropping problems by removing shadow from drawRect and using CALayer instead (requires import of QuartzCore.h). 
![shadow-fix](https://f.cloud.github.com/assets/1586504/120712/95d7e240-6d23-11e2-8ff6-794d7a8ab177.png)

Added hasShadow BOOL property (part of issue #28).
