### PR TITLE
Use Application keyWindow when presenting from a BarButtonItem

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -447,8 +447,7 @@
 	UIView *targetSuperview = [targetView superview];
 	UIView *containerView = nil;
 	if ([targetSuperview isKindOfClass:[UINavigationBar class]]) {
-		UINavigationController *navController = [(UINavigationBar *)targetSuperview delegate];
-		containerView = [[navController topViewController] view];
+      containerView = [UIApplication sharedApplication].keyWindow;
 	}
 	else if ([targetSuperview isKindOfClass:[UIToolbar class]]) {
 		containerView = [targetSuperview superview];


### PR DESCRIPTION
If the ViewController is a TableViewController then when presenting from a BarButtonItem the topViewController is selected as the containerWindow. 

The problem is this case is that the PopTip view would scroll with the table view.

My suggested solution is to use the Application's keyWindow.
