### PR TITLE
Make popTipViewWasDismissedByUser: an optional delegate method

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -146,5 +146,6 @@ typedef enum {
 
 
 @protocol CMPopTipViewDelegate <NSObject>
+@optional
 - (void)popTipViewWasDismissedByUser:(CMPopTipView *)popTipView;
 @end

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -537,7 +537,9 @@
 
 - (void)notifyDelegatePopTipViewWasDismissedByUser {
 	__strong id<CMPopTipViewDelegate> delegate = self.delegate;
-	[delegate popTipViewWasDismissedByUser:self];
+    if ([delegate respondsToSelector:@selector(popTipViewWasDismissedByUser:)]) {
+	   [delegate popTipViewWasDismissedByUser:self];
+    }
 }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {


### PR DESCRIPTION
Since there's really no reason for this method to be required.
