### PR TITLE
Fix rendering under iOS7 with 64-bit without breaking backwards compatibility.

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -260,7 +260,7 @@
             titleParagraphStyle.lineBreakMode = NSLineBreakByClipping;
             
             [self.title drawWithRect:titleFrame
-                             options:kNilOptions
+                             options:NSStringDrawingUsesLineFragmentOrigin
                           attributes:@{
                                        NSFontAttributeName: self.titleFont,
                                        NSForegroundColorAttributeName: self.titleColor,


### PR DESCRIPTION
Uses -drawWithRect:options:attributes:context: and -boundingRectWithSize:options:attributes:context: when they are available, falls back to the iOS6 methods if not.

Tested using the demo app on iPhone/iPad simulators under 6.0, 6.1, 7.0 and 7.1b5 and on device under 7.1b5.
