### PR TITLE
Orientation can be incorrect when presented from bar button item

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -581,13 +581,7 @@
 - (void)presentPointingAtBarButtonItem:(UIBarButtonItem *)barButtonItem animated:(BOOL)animated {
 	UIView *targetView = (UIView *)[barButtonItem performSelector:@selector(view)];
 	UIView *targetSuperview = [targetView superview];
-	UIView *containerView = nil;
-	if ([targetSuperview isKindOfClass:[UINavigationBar class]]) {
-		containerView = [UIApplication sharedApplication].keyWindow;
-	}
-	else if ([targetSuperview isKindOfClass:[UIToolbar class]]) {
-		containerView = [targetSuperview superview];
-	}
+	UIView *containerView = [targetSuperview superview];
 	
 	if (nil == containerView) {
 		NSLog(@"Cannot determine container view from UIBarButtonItem: %@", barButtonItem);


### PR DESCRIPTION
This is the fix for issue #57 and #62, where the pop tip views are presented in portrait even though the device is not in portrait.
