### PR TITLE
Added missing call to [super layoutSubviews]

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -70,6 +70,8 @@
 		CGRect contentFrame = [self contentFrame];
         [self.customView setFrame:contentFrame];
     }
+    
+    [super layoutSubviews];
 }
 
 - (void)drawRect:(__unused CGRect)rect


### PR DESCRIPTION
If you use a custom view, in some cases the app will crash due to a missing call to super in layoutSubviews.