### PR TITLE
Introduce new method `isBeingShown` to query whether the tooltip is already being presented

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -133,6 +133,7 @@ typedef enum {
 @property (nonatomic, assign)           CGFloat                 pointerSize;
 
 /* Contents can be either a message or a UIView */
+- (BOOL)isBeingShown;
 - (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow;
 - (id)initWithMessage:(NSString *)messageToShow;
 - (id)initWithCustomView:(UIView *)aView;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -739,6 +739,11 @@
   return _pointDirection;
 }
 
+- (BOOL)isBeingShown
+{
+	return self.targetObject != nil;
+}
+
 - (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow
 {
 	CGRect frame = CGRectZero;


### PR DESCRIPTION
Introduce new method `isBeingShown` to query whether the tooltip is
already being presented. For example, this helps in case you want to
present the tooltip by single tapping another UIView object. If you
simply call `presentPointingAtView`, it will rebuild the entire view
and re-animate its presentation.

Please, let me know if you have a better idea to accomplish the same :-)