### PR TITLE
Using UIGestureRecognizer and UIGestureRecognizerDelegate instead of a giant UIButton

### DIFF
--- a/CMPopTipView.podspec
+++ b/CMPopTipView.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name     = 'CMPopTipView'
-  s.version  = '2.2.2'
+  s.version  = '2.2.3'
   s.license  = 'MIT'
   s.summary  = 'Custom UIView for iOS that pops up an animated "bubble" pointing at a button or other view. Useful for popup tips.'
   s.homepage = 'https://github.com/vittoriom/CMPopTipView'
-  s.source   = { :git => 'https://github.com/vittoriom/CMPopTipView.git', :tag => '2.2.2' }
+  s.source   = { :git => 'https://github.com/vittoriom/CMPopTipView.git', :tag => '2.2.3' }
   s.platform = :ios
   s.source_files = 'CMPopTipView/*.{h,m}'
   s.framework = 'UIKit'

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -359,7 +359,7 @@
         self.dismissTarget = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissTapAnywhereFired:)];
         self.dismissTarget.delegate = self;
         self.containerView = containerView;
-        [containerView addGestureRecognizer:self.dismissTarget];
+        [containerView.window addGestureRecognizer:self.dismissTarget];
     }
 	
 	[containerView addSubview:self];
@@ -600,7 +600,7 @@
 	[self.autoDismissTimer invalidate]; self.autoDismissTimer = nil;
 
     if (self.dismissTarget) {
-        [self.containerView removeGestureRecognizer:self.dismissTarget];
+        [self.containerView.window removeGestureRecognizer:self.dismissTarget];
 		self.dismissTarget = nil;
     }
 	


### PR DESCRIPTION
These commits make it possible to remove the giant <code>UIButton</code> used to dismiss the tip view, and use a <code>UITapGestureRecognizer</code> on the <code>containerView</code> window instead. A single tap can now dismiss the tip view and also trigger any action associated with the tapped view object. 
