### PR TITLE
Fix issue with fractional title/message sizes

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -252,7 +252,7 @@
 	// Draw title and text
     if (self.title) {
         [self.titleColor set];
-        CGRect titleFrame = [self contentFrame];
+        CGRect titleFrame = CGRectIntegral([self contentFrame]);
         
         if ([self.title respondsToSelector:@selector(drawWithRect:options:attributes:context:)]) {
             NSMutableParagraphStyle *titleParagraphStyle = [[NSMutableParagraphStyle alloc] init];
@@ -286,7 +286,7 @@
 	
 	if (self.message) {
 		[self.textColor set];
-		CGRect textFrame = [self contentFrame];
+		CGRect textFrame = CGRectIntegral([self contentFrame]);
         
         // Move down to make room for title
         if (self.title) {


### PR DESCRIPTION
Text being drawn with fractional sizes may not always render
properly—see the [NSString UIKit Additions Reference](https://developer.apple.com/library/ios/documentation/uikit/reference/NSString_UIKit_Additions/Reference/Reference.html#//apple_ref/doc/uid/TP40006893-CH3-SW37) for more info.

This commit just changes the working frames (for both the title and message) to a rounded equivalent.

Here's an example, before the change:
![Before the Change](http://i.imgur.com/3LqgFfi.png)
... and after:
![After the Change](http://i.imgur.com/EsxwSd5.png)