### PR TITLE
Padding added to the content frame inside of the bubble

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -131,6 +131,8 @@ typedef NS_ENUM(NSInteger, CMPopTipAnimation) {
 @property (nonatomic, assign)           CGFloat                 sidePadding;
 @property (nonatomic, assign)           CGFloat                 topMargin;
 @property (nonatomic, assign)           CGFloat                 pointerSize;
+@property (nonatomic, assign)           CGFloat                 bubblePaddingX;
+@property (nonatomic, assign)           CGFloat                 bubblePaddingY;
 
 /* Contents can be either a message or a UIView */
 - (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -34,6 +34,8 @@
 	PointDirection			_pointDirection;
 	CGFloat					_pointerSize;
 	CGPoint					_targetPoint;
+	CGFloat					_bubblePaddingX;
+	CGFloat					_bubblePaddingY;
 }
 
 @property (nonatomic, strong, readwrite)	id	targetObject;
@@ -57,10 +59,10 @@
 
 - (CGRect)contentFrame {
 	CGRect bubbleFrame = [self bubbleFrame];
-	CGRect contentFrame = CGRectMake(bubbleFrame.origin.x + _cornerRadius,
-									 bubbleFrame.origin.y + _cornerRadius,
-									 bubbleFrame.size.width - _cornerRadius*2,
-									 bubbleFrame.size.height - _cornerRadius*2);
+	CGRect contentFrame = CGRectMake(bubbleFrame.origin.x + _cornerRadius + _bubblePaddingX,
+									 bubbleFrame.origin.y + _cornerRadius + _bubblePaddingY,
+									 bubbleFrame.size.width - (_bubblePaddingX*2) - (_cornerRadius*2),
+									 bubbleFrame.size.height - (_bubblePaddingY*2) - (_cornerRadius*2));
 	return contentFrame;
 }
 
@@ -459,7 +461,7 @@
         textSize.height += titleSize.height;
     }
     
-	_bubbleSize = CGSizeMake(textSize.width + _cornerRadius*2, textSize.height + _cornerRadius*2);
+	_bubbleSize = CGSizeMake(textSize.width + (_bubblePaddingX*2) + (_cornerRadius*2), textSize.height + (_bubblePaddingY*2) + (_cornerRadius*2));
 	
 	UIView *superview = containerView.superview;
 	if ([superview isKindOfClass:[UIWindow class]])


### PR DESCRIPTION
When changing the cornerRadius of a bubble it will remove all padding in regards to the content frame. This makes it so there is minimal space to the text that's inside of the bubble. 

sidePadding doesn't solve this issue as it is only affecting the padding between the window and the full bubble, not the side padding in the bubble itself.

In the code below I am adding the bubblePadding property to the bubble size to make the size of the bubble bigger. I then change the Rect of the content frame for the correct padding to be added.