### PR TITLE
解决某些情况下，dismisstarget放到后边会影响其他点击事件。

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -349,7 +349,10 @@
 }
 
 - (void)presentPointingAtView:(UIView *)targetView inView:(UIView *)containerView animated:(BOOL)animated {
-	if (!self.targetObject) {
+	
+    [containerView addSubview:self];
+    
+    if (!self.targetObject) {
 		self.targetObject = targetView;
 	}
     
@@ -363,8 +366,6 @@
         [containerView addSubview:self.dismissTarget];
     }
 	
-	[containerView addSubview:self];
-    
 	// Size of rounded rect
 	CGFloat rectWidth;
     


### PR DESCRIPTION
如果dismisstarget在popTipView后边，此时点击popTipView会影响到popTipView后边View的点击事件
![qq20150527-1](https://cloud.githubusercontent.com/assets/4197468/7828240/717ad0cc-0463-11e5-9e5c-d0f116160afd.jpg)
