### PR TITLE
Added dismissAlongWithUserInteraction property.

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -135,7 +135,7 @@ typedef NS_ENUM(NSInteger, CMPopTipAnimation) {
 @property (nonatomic, assign)           CGFloat                 bubblePaddingY;
 
 /**
- Dismiss along with user interaction if YES. For example, users can scroll down a table view when a tip view is shown. The tip view dismiss when he or she touches down and user interaction continues.
+ Dismiss along with user interaction if YES. For example, users can scroll down a table view when a tip view is shown. The tip view dismiss when he or she touches down and user interaction continues. Default is NO.
  @note Make sure `dismissTapAnywhere` is NO.
  */
 @property (nonatomic, assign)           BOOL                    dismissAlongWithUserInteraction;

--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -134,6 +134,12 @@ typedef NS_ENUM(NSInteger, CMPopTipAnimation) {
 @property (nonatomic, assign)           CGFloat                 bubblePaddingX;
 @property (nonatomic, assign)           CGFloat                 bubblePaddingY;
 
+/**
+ Dismiss along with user interaction if YES. For example, users can scroll down a table view when a tip view is shown. The tip view dismiss when he or she touches down and user interaction continues.
+ @note Make sure `dismissTapAnywhere` is NO.
+ */
+@property (nonatomic, assign)           BOOL                    dismissAlongWithUserInteraction;
+
 /* Contents can be either a message or a UIView */
 - (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow;
 - (id)initWithMessage:(NSString *)messageToShow;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -667,6 +667,16 @@
 	[self dismissByUser];
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    if (self.dismissAlongWithUserInteraction) {
+        [self dismissAnimated:YES];
+        [self notifyDelegatePopTipViewWasDismissedByUser];
+        return nil;
+    }
+    
+    return [super hitTest:point withEvent:event];
+}
+
 - (void)dismissTapAnywhereFired:(__unused UIButton *)button
 {
 	[self dismissByUser];

--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ Available Options
 * **CGFloat**                 pointerSize
 * **CGFloat**                 bubblePaddingX
 * **CGFloat**                 bubblePaddingY
-
+* **BOOL**        	          dismissAlongWithUserInteraction
 
 ARC
 ---


### PR DESCRIPTION
Dismiss along with user interaction if YES. For example, users can scroll down a table view when a tip view is shown. The tip view dismiss when he or she touches down and user interaction continues. Default is NO.

-

It's a great way to show information to users using tip views and I use CMPopTipView in two of my apps. Thank you so much.👍

I think it's better to dismiss directly in some situations. Sometimes it's unnecessary to make user tap to dismiss. Assume that when a user taps a button and hope to push to a new view controller, but the tip view stops the action to dismiss itself. It's not what the user wants. And we can just dismiss the tip view and make the push-to-a-new-view-controller button works at the same time. It's better, isn't it? 

I'm not a native English speaker. The property name and the comment may not so good. Help me to make it better please. : )