### PR TITLE
Adds "hideAfter" property to hide tip after n seconds

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -133,6 +133,7 @@ typedef NS_ENUM(NSInteger, CMPopTipAnimation) {
 @property (nonatomic, assign)           CGFloat                 pointerSize;
 @property (nonatomic, assign)           CGFloat                 bubblePaddingX;
 @property (nonatomic, assign)           CGFloat                 bubblePaddingY;
+@property (nonatomic, assign)           NSTimeInterval          hideAfter;
 
 /* Contents can be either a message or a UIView */
 - (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -346,6 +346,10 @@
 #pragma clang diagnostic pop
 
         }
+
+        if (self.hideAfter) {
+            [self performSelector:@selector(dismissByUser) withObject:nil afterDelay:self.hideAfter];
+        }
     }
 }
 


### PR DESCRIPTION
I use this in my app and it seems like a useful feature to add.

Usage:
```
CMPopTipView * tipView = [[CMPopTipView alloc] initWithMessage:@"Won't last forever!"];
tipView.delegate = self;
tipView.hideAfter = 5;
[tipView presentPointingAtView:headerImage inView:self.view animated:YES];
```

And the tipView will automatically close after 5 seconds.