### PR TITLE
iOS 11 Bugfix: Find the correct container-view when a poptip is prese…

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -593,9 +593,16 @@
 
 - (void)presentPointingAtBarButtonItem:(UIBarButtonItem *)barButtonItem animated:(BOOL)animated {
 	UIView *targetView = (UIView *)[barButtonItem performSelector:@selector(view)];
-	UIView *targetSuperview = [targetView superview];
-	UIView *containerView = [targetSuperview superview];
-	
+    // Try to find the superview of the UINavigationBar. Limit the number of tries to 8.
+    UIView *containerView = targetView.superview;
+    for(NSInteger i = 0; i < 8; ++i) {
+        if([containerView isKindOfClass:[UINavigationBar class]]) {
+            containerView = containerView.superview;
+            break;
+        }
+        containerView = containerView.superview;
+    }
+
 	if (nil == containerView) {
 		NSLog(@"Cannot determine container view from UIBarButtonItem: %@", barButtonItem);
 		self.targetObject = nil;


### PR DESCRIPTION
In iOS 11, the view-hierarchy of UINavigationBars changed. Thus, the poptip and button to dismiss is not added on the superview of the UINavigationBar, but on the UINavigationBar instead.
This patch traverses the superviews of the UIBarButtonItem-view and tries to find the UINavigationBar and chooses its superview.