### PR TITLE
Solution for bubble padding (issue #132)

### DIFF
--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -139,7 +139,7 @@ typedef NS_ENUM(NSInteger, CMPopTipAnimation) {
  @note Make sure `dismissTapAnywhere` is NO.
  */
 @property (nonatomic, assign)           BOOL                    dismissAlongWithUserInteraction;
-@property (nonatomic, assign)           BOOL                    shouldEnforceCustomViewPadding;
+@property (nonatomic, assign)           BOOL                    shouldEnforceCustomViewPadding __attribute__((deprecated("This property is no longer required. Padding is automatically applied when using bubblePaddingX, bubblePaddingY or cornerRadius.")));
 @property (nonatomic, assign)           BOOL                    shouldMaskCustomView;
 
 /* Contents can be either a message or a UIView */

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -59,17 +59,12 @@
 
 - (CGRect)contentFrame {
     CGRect bubbleFrame = [self bubbleFrame];
-
-    if (self.shouldEnforceCustomViewPadding) {
-				CGRect contentFrame = CGRectMake(bubbleFrame.origin.x + _cornerRadius + _bubblePaddingX,
-												 bubbleFrame.origin.y + _cornerRadius + _bubblePaddingY,
-												 bubbleFrame.size.width - (_bubblePaddingX*2) - (_cornerRadius*2),
-												 bubbleFrame.size.height - (_bubblePaddingY*2) - (_cornerRadius*2));
-        return contentFrame;
-    }
-    else {
-        return bubbleFrame;
-    }
+    
+    CGRect contentFrame = CGRectMake(bubbleFrame.origin.x + _cornerRadius + _bubblePaddingX,
+                                     bubbleFrame.origin.y + _cornerRadius + _bubblePaddingY,
+                                     bubbleFrame.size.width - (_bubblePaddingX*2) - (_cornerRadius*2),
+                                     bubbleFrame.size.height - (_bubblePaddingY*2) - (_cornerRadius*2));
+    return contentFrame;
 }
 
 - (void)layoutSubviews {
@@ -480,12 +475,7 @@
         textSize.height += titleSize.height;
     }
 
-    if (self.shouldEnforceCustomViewPadding) {
-				_bubbleSize = CGSizeMake(textSize.width + (_bubblePaddingX*2) + (_cornerRadius*2), textSize.height + (_bubblePaddingY*2) + (_cornerRadius*2));
-    }
-    else {
-        _bubbleSize = CGSizeMake(textSize.width, textSize.height);
-    }
+	_bubbleSize = CGSizeMake(textSize.width + (_bubblePaddingX*2) + (_cornerRadius*2), textSize.height + (_bubblePaddingY*2) + (_cornerRadius*2));
 
 	UIView *superview = containerView.superview;
 	if ([superview isKindOfClass:[UIWindow class]])
@@ -830,7 +820,6 @@
 
 	if ((self = [self initWithFrame:frame])) {
 		self.customView = aView;
-        self.shouldEnforceCustomViewPadding = YES;
         self.shouldMaskCustomView = YES;
         [self addSubview:self.customView];
 	}

--- a/Demo/Shared/Demo1ViewController.m
+++ b/Demo/Shared/Demo1ViewController.m
@@ -94,7 +94,6 @@
 		
 		/* Some options to try.
 		 */
-        //popTipView.shouldEnforceCustomViewPadding = YES;
 		//popTipView.disableTapToDismiss = YES;
 		//popTipView.preferredPointDirection = PointDirectionUp;
 		//popTipView.hasGradientBackground = NO;


### PR DESCRIPTION
This is the solution for issue https://github.com/chrismiles/CMPopTipView/issues/132 by removing `shouldEnforceCustomViewPadding`.
I have added a deprecation warning in the header file, so users who have this property in their code will see an Xcode warning when updating to the new version.