### PR TITLE
Prevent dismissTarget from being repeatedly added to containerView.

### DIFF
--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -370,7 +370,7 @@
 
     // If we want to dismiss the bubble when the user taps anywhere, we need to insert
     // an invisible button over the background.
-    if ( self.dismissTapAnywhere ) {
+    if ( self.dismissTapAnywhere && !self.dismissTarget ) {
         self.dismissTarget = [UIButton buttonWithType:UIButtonTypeCustom];
         [self.dismissTarget addTarget:self action:@selector(dismissTapAnywhereFired:) forControlEvents:UIControlEventTouchUpInside];
         [self.dismissTarget setTitle:@"" forState:UIControlStateNormal];


### PR DESCRIPTION
If you call two times - (void) presentPointingAtView: (UIView *) targetView inView: (UIView *) containerView animated: (BOOL) animated, then you can't hide pop correctly